### PR TITLE
1.4.8
Edited exception add data to use dictionaries for collation of data per "execution key" instead of keys per variable added

### DIFF
--- a/Praxis.Test/Praxis.Test.csproj
+++ b/Praxis.Test/Praxis.Test.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Praxis.Data\Praxis.Data.csproj" />
     <ProjectReference Include="..\Praxis.Knowledge\Praxis.Knowledge.csproj" />
     <ProjectReference Include="..\Praxis.LiteDb\Praxis.LiteDb.csproj" />
+    <ProjectReference Include="..\Praxis.Logging\Praxis.Logging.csproj" />
     <ProjectReference Include="..\Praxis.Web\Praxis.Web.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Edited exception add data to use dictionaries for collation of data per "execution key" instead of keys per variable added

altered test for exception adddata